### PR TITLE
Makes windows build work and fixes character width issue

### DIFF
--- a/libdxfeed-sys/build.rs
+++ b/libdxfeed-sys/build.rs
@@ -76,12 +76,29 @@ fn main() {
         .build();
 
     println!("cargo:rustc-link-search=native={}", dst.display());
+
+    #[cfg(unix)]
     println!("cargo:rustc-link-search=native={}/build", dst.display());
+
+    #[cfg(windows)]
+    {
+        println!(
+            "cargo:rustc-link-search=native={}/build/Debug",
+            dst.display()
+        );
+        println!(
+            "cargo:rustc-link-search=native={}/build/Release",
+            dst.display()
+        );
+    }
+
     // println!("cargo:rustc-link-search={}", dst.display());
 
     let profile = std::env::var("PROFILE").unwrap();
     let suffix = if profile == "debug" { "d" } else { "" };
     println!("cargo:rustc-link-lib=static={}{}", "DXFeed", suffix);
+
+    #[cfg(unix)]
     println!("cargo:rustc-link-lib=stdc++");
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes


### PR DESCRIPTION
Hi, I've fixed a couple things that prevented me from successfully using the library on Windows:

- Pointed cargo to the correct build directories and removed stdc++ dependency;
- Replaced `U32CString` with `WideCString`, because wchar_t on Windows is 16 bits wide, as opposed to 32 bits on Unix. This caused strings to get truncated after the first character. `WideCString` is an alias that works out to the correct width.

I've tested this with the example program (after removing signal handling) and it appears to work correctly. I have not tested on Unix.

To run this locally you'll need to change Cargo.toml to use the local `libdxfeed-sys`, wasted like 15 minutes on that...