### PR TITLE
Update Cargo.toml

### DIFF
--- a/samples/quote_sub_example/Cargo.toml
+++ b/samples/quote_sub_example/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.70"
 crossbeam-channel = "0.5.7"
-dxfeed = "0.1.11"
+dxfeed = "0.2.3"
 serde = "1.0.159"
 serde_json = "1.0.95"
 signal-hook = "0.3.15"


### PR DESCRIPTION
dxfeed version 0.1.11 seems out of date and potentially includes a dependency with outdated build flags without considering macos as a target, leading to a linker error of "note: ld: library 'stdc++' not found" linker error when trying to run "cargo run" from the samples/quote_sub_example on MacOS. 

After some research I noticed the dxfeed directory in this project has a version of 0.2.3, which uses libdxfeed-sys of 0.2.1, which has a build.rs file which looks like it considers the macos target and links the proper library.

So I changed the dxfeed version from 0.1.11 to the latest of 0.2.3 and the linking error went away and I was able to compile.